### PR TITLE
Added Swashbuckle.SwaggerGen package

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,3 +8,5 @@
 - dotnet new webapi -n backend -controllers
 # Gitignore
 - [reactjs/React.NET](https://github.com/reactjs/React.NET/blob/main/.gitignore)
+## .NET Packages
+- dotnet add backend.csproj package Swashbuckle.AspNetCore

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -6,15 +6,22 @@ builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 
+// Add services for Swagger Gen
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
+if (app.Environment.IsDevelopment()) {
     app.MapOpenApi();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();
+
+app.MapSwagger().RequireAuthorization();
 
 app.UseAuthorization();
 

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added the SwaggerGen service and set the app when in dev to serve SwaggerGen. Run the backend and go to /swagger to see all the endpoints, currently only the default weather template one.